### PR TITLE
fix(s3-upload): use relative import for util package

### DIFF
--- a/src/transfer/gcs.py
+++ b/src/transfer/gcs.py
@@ -5,7 +5,7 @@ import google.auth
 import google.auth.exceptions
 from google.cloud import storage
 from google.cloud.storage import Client
-from .util.fileutils import make_cloud_paths, collect_filepaths
+from transfer.util.fileutils import make_cloud_paths, collect_filepaths
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/src/transfer/s3.py
+++ b/src/transfer/s3.py
@@ -12,7 +12,7 @@ from s3transfer.constants import GB, MB
 from s3transfer.crt import (BotocoreCRTRequestSerializer, CRTTransferFuture,
                             CRTTransferManager, create_s3_crt_client)
 
-from .util.fileutils import collect_filepaths, make_cloud_paths
+from transfer.util.fileutils import collect_filepaths, make_cloud_paths
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/src/transfer/s3.py
+++ b/src/transfer/s3.py
@@ -12,7 +12,7 @@ from s3transfer.constants import GB, MB
 from s3transfer.crt import (BotocoreCRTRequestSerializer, CRTTransferFuture,
                             CRTTransferManager, create_s3_crt_client)
 
-from util.fileutils import collect_filepaths, make_cloud_paths
+from .util.fileutils import collect_filepaths, make_cloud_paths
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/tests/test_gcs_uploader.py
+++ b/tests/test_gcs_uploader.py
@@ -1,0 +1,20 @@
+import unittest
+
+from transfer.gcs import GCSUploader
+
+
+class TestGCSUploader(unittest.TestCase):
+    """Tests methods defined in GCSUploader class"""
+
+    def test_gcs_uploader_init(self):
+        """Checks that the GCSUploader can be instantiated. Since GCSUploader
+        initializes a cloud storage client, we'll test that it throws an
+        error if the bucket_name is None.
+        """
+
+        with self.assertRaises(ValueError):
+            GCSUploader(bucket_name=None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_s3_transfer.py
+++ b/tests/test_s3_transfer.py
@@ -1,0 +1,16 @@
+import unittest
+
+from transfer.s3 import S3Uploader
+
+
+class TestS3Uploader(unittest.TestCase):
+    """Tests methods defined in S3Uploader class"""
+
+    def test_s3_uploader_init(self):
+        """Tests that the S3Uploader can be instantiated."""
+        uploader = S3Uploader()
+        self.assertIsNotNone(uploader)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
fixed an `ModuleNotFoundError: No module named 'util'` error with a fresh conda environment, though I'm no longer able to reproduce it. 