### PR TITLE
wavpack-numcodecs v0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     'spikeinterface[full]',
     'probeinterface>=0.2.11',
     'zarr',
-    'wavpack-numcodecs>=0.1.2'
+    'wavpack-numcodecs>=0.1.3'
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
@dyf @jtyoung84 

We found a much better solution to the wavpack buffer size problem. Basically now the decoder can read the number of decompressed samples beforehand, so we can allocate the right size for the output buffer.

Released in `wavpack-numcodecs` 0.1.3