### PR TITLE
feat: Splits ephys and imaging dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: python -m pip install -e .[dev,full]
+      run: python -m pip install -e .[dev]
     - name: Run linters
       run: black . && interrogate . && isort .
     - name: Run tests and coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: python -m pip install -e .[dev]
+      run: python -m pip install -e .[dev,full]
     - name: Run linters
       run: black . && interrogate . && isort .
     - name: Run tests and coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    'nd-data-transfer[full]',
     'black',
     'coverage',
     'flake8',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,21 +16,8 @@ dependencies = [
     'pandas',
     's3transfer[crt]',
     'numpy>=1.16',
-    'dask-jobqueue',
-    'dask-image',
-    'bokeh>=2.1.1',
     'pyyaml',
-    'google-cloud-storage',
-    'ome-zarr@git+https://github.com/camilolaiton/ome-zarr-py.git@feature/delayed-dask-poc',
-    'aicsimageio@git+https://github.com/camilolaiton/aicsimageio.git@feature/zarrwriter-multiscales-daskjobs',
-    'hdf5plugin@https://github.com/silx-kit/hdf5plugin/archive/refs/tags/v3.3.1.tar.gz',
-    'gcsfs',
-    'xarray-multiscale',
-    'parameterized',
-    'spikeinterface[full]',
-    'probeinterface>=0.2.11',
-    'zarr',
-    'wavpack-numcodecs>=0.1.3'
+    'google-cloud-storage'
 ]
 
 [project.optional-dependencies]
@@ -41,6 +28,27 @@ dev = [
     'interrogate',
     'isort',
     'Sphinx'
+]
+ephys = [
+    'spikeinterface[full]',
+    'probeinterface>=0.2.11',
+    'zarr',
+    'wavpack-numcodecs>=0.1.3'
+]
+imaging = [
+    'dask-jobqueue',
+    'dask-image',
+    'bokeh>=2.1.1',
+    'ome-zarr@git+https://github.com/camilolaiton/ome-zarr-py.git@feature/delayed-dask-poc',
+    'aicsimageio@git+https://github.com/camilolaiton/aicsimageio.git@feature/zarrwriter-multiscales-daskjobs',
+    'hdf5plugin@https://github.com/silx-kit/hdf5plugin/archive/refs/tags/v3.3.1.tar.gz',
+    'gcsfs',
+    'xarray-multiscale',
+    'parameterized'
+]
+full = [
+    'nd-data-transfer[ephys]',
+    'nd-data-transfer[imaging]'
 ]
 
 [tool.setuptools.packages.find]

--- a/src/transfer/__init__.py
+++ b/src/transfer/__init__.py
@@ -8,4 +8,4 @@ LOG_DATE_FMT = "%Y-%m-%d %H:%M"
 
 logging.basicConfig(format=LOG_FMT, datefmt=LOG_DATE_FMT)
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"


### PR DESCRIPTION
Closes #65

Slightly different than the behavior in the ticket. 
`pip install .[ephys]`
`pip install .[imaging]`
`pip install .[full]` for both ephys and imaging
`pip install .` just installs the packages in the dependencies list (the stuff shared by ephys and imaging)